### PR TITLE
change -dev to -D in npm install -dev nuxt-gsap

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 1. Add `nuxt-gsap` dependency to your project
 
 ```bash
-yarn add --dev nuxt-gsap # or npm install --dev nuxt-gsap
+yarn add --dev nuxt-gsap # or npm install -D nuxt-gsap
 ```
 
 2. Add `nuxt-gsap` to the `buildModules` section of `nuxt.config.js`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 1. Add `nuxt-gsap` dependency to your project
 
 ```bash
-yarn add --dev nuxt-gsap # or npm install -dev nuxt-gsap
+yarn add --dev nuxt-gsap # or npm install --dev nuxt-gsap
 ```
 
 2. Add `nuxt-gsap` to the `buildModules` section of `nuxt.config.js`


### PR DESCRIPTION
add dash (-) to `-dev` in ` npm install --dev nuxt-gsap` since `-dev` is deprecated